### PR TITLE
Unit test

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -21,6 +21,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential cmake g++  # Install build tools
           sudo apt-get install -y libgtest-dev  # Install Google Test
+          sudo apt-get install -y libhidapi-dev
           cd /usr/src/gtest && sudo cmake . && sudo make   # Build Google Test library
 
       - name: Build Project

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -21,7 +21,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential cmake g++  # Install build tools
           sudo apt-get install -y libgtest-dev  # Install Google Test
-          cd /usr/src/gtest && sudo cmake . && sudo make && sudo cp *.a /usr/lib  # Build Google Test library
+          cd /usr/src/gtest && sudo cmake . && sudo make   # Build Google Test library
 
       - name: Build Project
         run: |

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -6,7 +6,7 @@ on:
       - unit_test  
   pull_request:
     branches:
-      - unit_test  
+      - main  
 
 jobs:
   build:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,0 +1,37 @@
+name: Unit Tests
+
+on:
+  push:
+    branches:
+      - unit_test  
+  pull_request:
+    branches:
+      - unit_test  
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake g++  # Install build tools
+          sudo apt-get install -y libgtest-dev  # Install Google Test
+          cd /usr/src/gtest && sudo cmake . && sudo make && sudo cp *.a /usr/lib  # Build Google Test library
+
+      - name: Build Project
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          cmake --build .
+
+      - name: Run Tests
+        run: |
+          cd build
+          ctest  
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,38 @@ target_link_libraries(g29_text_example
         ${HIDAPI_LIBRARIES}
 )
 
+
+# Google Test
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+# Enable testing
+enable_testing()
+
+# Add the test executable
+add_executable(G29Test
+  test/G29Test.cpp
+)
+
+target_link_libraries(G29Test
+  PRIVATE
+    G29
+    ${HIDAPI_LIBRARIES}
+    gtest_main
+    gmock_main
+)
+
+# Include the Google Test module
+include(GoogleTest)
+
+# Discover tests
+gtest_discover_tests(G29Test)
 # Install rules
 # install(TARGETS G29 g29_example
 #     RUNTIME DESTINATION bin

--- a/src/G29.cpp
+++ b/src/G29.cpp
@@ -1,5 +1,6 @@
 #include "G29.hpp"
 #include <iostream>
+#include <algorithm>  
 
 G29::G29() {
     if (hid_init() != 0) {
@@ -132,35 +133,36 @@ uint8_t G29::calculateSteering(uint8_t start, uint8_t end) const {
 
 std::string G29::updateButtonState(const std::vector<uint8_t>& byteArray) {
     if (byteArray.size() < 16) return "";
+    //buttonState.clear();
 
-    buttonState["X"] = (byteArray[0] == 0x18);
-    buttonState["Square"] = (byteArray[0] == 0x28);
-    buttonState["Triangle"] = (byteArray[0] == 0x88);
-    buttonState["Circle"] = (byteArray[0] == 0x48);
+     // Correct the conditions and ensure they are distinct
+    buttonState["X"] = (byteArray[0] & 0x18) == 0x18;
+    buttonState["Square"] = (byteArray[0] & 0x28) == 0x28;
+    buttonState["Triangle"] = (byteArray[0] & 0x88) == 0x88;
+    buttonState["Circle"] = (byteArray[0] & 0x48) == 0x48;
 
-    buttonState["L2"] = (byteArray[1] == 0x08);
-    buttonState["R2"] = (byteArray[1] == 0x04);
-    buttonState["L3"] = (byteArray[1] == 0x80);
-    buttonState["R3"] = (byteArray[1] == 0x40);
+    buttonState["L2"] = (byteArray[1] & 0x08) == 0x08;
+    buttonState["R2"] = (byteArray[1] & 0x04) == 0x04;
+    buttonState["L3"] = (byteArray[1] & 0x80) == 0x80;
+    buttonState["R3"] = (byteArray[1] & 0x40) == 0x40;
 
-    buttonState["DPadUp"] = (byteArray[0] == 0x00);
-    buttonState["DPadDown"] = (byteArray[0] == 0x04);
-    buttonState["DPadLeft"] = (byteArray[0] == 0x06);
-    buttonState["DPadRight"] = (byteArray[0] == 0x02);
+    buttonState["DPadUp"] = (byteArray[0] & 0x0F) == 0x00;  // Mask with 0x0F for directional checks
+    buttonState["DPadDown"] = (byteArray[0] & 0x0F) == 0x04;
+    buttonState["DPadLeft"] = (byteArray[0] & 0x0F) == 0x06;
+    buttonState["DPadRight"] = (byteArray[0] & 0x0F) == 0x02;
 
-    buttonState["RotaryDialPress"] = (byteArray[3] == 0x08);
+    buttonState["RotaryDialPress"] = (byteArray[3] & 0x08) == 0x08;
 
-    buttonState["PlusButton"] = (byteArray[2] == 0x80);
-    buttonState["MinusButton"] = (byteArray[3] == 0x01);
+    buttonState["PlusButton"] = (byteArray[2] & 0x80) == 0x80;
+    buttonState["MinusButton"] = (byteArray[3] & 0x01) == 0x01;
 
-    buttonState["LeftPaddle"] = (byteArray[1] == 0x02);
-    buttonState["RightPaddle"] = (byteArray[1] == 0x01);
+    buttonState["LeftPaddle"] = (byteArray[1] & 0x02) == 0x02;
+    buttonState["RightPaddle"] = (byteArray[1] & 0x01) == 0x01;
 
-    buttonState["Share"] = (byteArray[1] == 0x10);
-    buttonState["Options"] = (byteArray[1] == 0x20);
-    buttonState["PS"] = (byteArray[3] == 0x10);
-
-     
+    buttonState["Share"] = (byteArray[1] & 0x10) == 0x10;
+    buttonState["Options"] = (byteArray[1] & 0x20) == 0x20;
+    buttonState["PS"] = (byteArray[3] & 0x10) == 0x10;
+    // std::cout << "Button pressed: " << getPressedButton() << std::endl;
 
     if (byteArray[0] == 0x18) return "X";
     if (byteArray[0] == 0x28) return "Square";
@@ -191,6 +193,9 @@ std::string G29::updateButtonState(const std::vector<uint8_t>& byteArray) {
 
     return "";
 }
+
+
+
 
 bool G29::isButtonPressed(const std::string& button) const {
     auto it = buttonState.find(button);

--- a/src/G29.hpp
+++ b/src/G29.hpp
@@ -114,6 +114,16 @@ public:
      */
     std::string getPressedButton();
 
+    /**
+     * @brief Updates the state of all buttons based on raw input data.
+     * 
+     * @param byteArray The raw input data from the device.
+     * @return The name of the first pressed button found, or an empty string if no button is pressed.
+     */
+    std::string updateButtonState(const std::vector<uint8_t>& byteArray);
+
+
+
 private:
     hid_device* device;  ///< Pointer to the HID device.
     std::vector<uint8_t> cache;  ///< Buffer for storing raw input data.
@@ -136,11 +146,5 @@ private:
      */
     uint8_t calculateSteering(uint8_t start, uint8_t end) const;
 
-    /**
-     * @brief Updates the state of all buttons based on raw input data.
-     * 
-     * @param byteArray The raw input data from the device.
-     * @return The name of the first pressed button found, or an empty string if no button is pressed.
-     */
-    std::string updateButtonState(const std::vector<uint8_t>& byteArray);
+    
 };

--- a/test/G29Test.cpp
+++ b/test/G29Test.cpp
@@ -1,0 +1,212 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "../src/G29.hpp"  
+
+// Mock class for hid_device
+class MockHidDevice {
+public:
+    MOCK_METHOD(int, hid_write, (hid_device*, const unsigned char*, size_t));
+    MOCK_METHOD(int, hid_read_timeout, (hid_device*, unsigned char*, size_t, int));
+};
+
+// Mock class for hidapi functions
+class MockHidApi {
+public:
+    MOCK_METHOD(int, hid_init, ());
+    MOCK_METHOD(hid_device*, hid_open, (unsigned short, unsigned short, const wchar_t*));
+    MOCK_METHOD(void, hid_close, (hid_device*));
+    MOCK_METHOD(int, hid_exit, ());
+    MOCK_METHOD(int, hid_read, (hid_device*, unsigned char*, size_t));
+};
+
+// Global mock objects
+MockHidDevice* g_mockHidDevice;
+MockHidApi* g_mockHidApi;
+
+// Override global functions to use our mocks
+extern "C" {
+    int hid_init() { return g_mockHidApi->hid_init(); }
+    hid_device* hid_open(unsigned short vendor_id, unsigned short product_id, const wchar_t* serial_number) {
+        return g_mockHidApi->hid_open(vendor_id, product_id, serial_number);
+    }
+    int hid_read(hid_device* device, unsigned char* data, size_t length) {
+        return g_mockHidApi->hid_read(device, data, length);
+    }
+    void hid_close(hid_device* device) { g_mockHidApi->hid_close(device); }
+    int hid_exit() { return g_mockHidApi->hid_exit(); }
+    int hid_write(hid_device* device, const unsigned char* data, size_t length) {
+        return g_mockHidDevice->hid_write(device, data, length);
+    }
+    int hid_read_timeout(hid_device* device, unsigned char* data, size_t length, int milliseconds) {
+        return g_mockHidDevice->hid_read_timeout(device, data, length, milliseconds);
+    }
+}
+
+class G29Test : public ::testing::Test {
+protected:
+    void SetUp() override {
+        g_mockHidDevice = new MockHidDevice();
+        g_mockHidApi = new MockHidApi();
+        EXPECT_CALL(*g_mockHidApi, hid_close(testing::_)).Times(testing::AnyNumber());
+        EXPECT_CALL(*g_mockHidApi, hid_exit()).Times(testing::AnyNumber());
+    }
+
+    void TearDown() override {
+        delete g_mockHidDevice;
+        delete g_mockHidApi;
+    }
+};
+
+TEST_F(G29Test, ConstructorInitializesCorrectly) {
+    EXPECT_CALL(*g_mockHidApi, hid_init()).WillOnce(testing::Return(0));
+    EXPECT_CALL(*g_mockHidApi, hid_open(0x046d, 0xc24f, testing::_)).WillOnce(testing::Return(reinterpret_cast<hid_device*>(1)));
+
+    G29 g29;
+}
+
+TEST_F(G29Test, DestructorClosesDeviceAndExits) {
+    EXPECT_CALL(*g_mockHidApi, hid_init()).WillOnce(testing::Return(0));
+    EXPECT_CALL(*g_mockHidApi, hid_open(0x046d, 0xc24f, testing::_)).WillOnce(testing::Return(reinterpret_cast<hid_device*>(1)));
+    EXPECT_CALL(*g_mockHidApi, hid_close(testing::_));
+    EXPECT_CALL(*g_mockHidApi, hid_exit());
+
+    {
+        G29 g29;
+    }
+}
+
+TEST_F(G29Test, ResetSendsResetCommand) {
+    EXPECT_CALL(*g_mockHidApi, hid_init()).WillOnce(testing::Return(0));
+    EXPECT_CALL(*g_mockHidApi, hid_open(0x046d, 0xc24f, testing::_)).WillOnce(testing::Return(reinterpret_cast<hid_device*>(1)));
+    EXPECT_CALL(*g_mockHidDevice, hid_write(testing::_, testing::_, testing::_)).Times(testing::AtLeast(1));
+
+    G29 g29;
+    g29.reset();
+}
+
+TEST_F(G29Test, ForceFeedbackConstantSetsForce) {
+    EXPECT_CALL(*g_mockHidApi, hid_init()).WillOnce(testing::Return(0));
+    EXPECT_CALL(*g_mockHidApi, hid_open(0x046d, 0xc24f, testing::_)).WillOnce(testing::Return(reinterpret_cast<hid_device*>(1)));
+    EXPECT_CALL(*g_mockHidDevice, hid_write(testing::_, testing::_, testing::_)).Times(testing::AtLeast(1));
+
+    G29 g29;
+    EXPECT_NO_THROW(g29.forceFeedbackConstant(0.5f));
+    EXPECT_THROW(g29.forceFeedbackConstant(1.5f), std::out_of_range);
+}
+
+TEST_F(G29Test, SetAutocenterSetsEffect) {
+    EXPECT_CALL(*g_mockHidApi, hid_init()).WillOnce(testing::Return(0));
+    EXPECT_CALL(*g_mockHidApi, hid_open(0x046d, 0xc24f, testing::_)).WillOnce(testing::Return(reinterpret_cast<hid_device*>(1)));
+    EXPECT_CALL(*g_mockHidDevice, hid_write(testing::_, testing::_, testing::_)).Times(testing::AtLeast(1));
+
+    G29 g29;
+    EXPECT_NO_THROW(g29.setAutocenter(0.5f, 0.5f));
+    EXPECT_THROW(g29.setAutocenter(1.5f, 0.5f), std::out_of_range);
+    EXPECT_THROW(g29.setAutocenter(0.5f, 1.5f), std::out_of_range);
+}
+
+TEST_F(G29Test, ForceOffTurnsOffForce) {
+    EXPECT_CALL(*g_mockHidApi, hid_init()).WillOnce(testing::Return(0));
+    EXPECT_CALL(*g_mockHidApi, hid_open(0x046d, 0xc24f, testing::_)).WillOnce(testing::Return(reinterpret_cast<hid_device*>(1)));
+    EXPECT_CALL(*g_mockHidDevice, hid_write(testing::_, testing::_, testing::_)).Times(testing::AtLeast(1));
+
+    G29 g29;
+    g29.forceOff();
+}
+
+TEST_F(G29Test, PumpReadsData) {
+    EXPECT_CALL(*g_mockHidApi, hid_init()).WillOnce(testing::Return(0));
+    EXPECT_CALL(*g_mockHidApi, hid_open(0x046d, 0xc24f, testing::_))
+        .WillOnce(testing::Return(reinterpret_cast<hid_device*>(1)));
+
+    // Prepare mock data that matches the expected format
+    std::vector<unsigned char> mockData(16, 0);
+    // Fill mockData with appropriate test values
+    EXPECT_CALL(*g_mockHidApi, hid_read(testing::_, testing::_, testing::_))
+        .WillOnce(testing::DoAll(
+            testing::SetArrayArgument<1>(mockData.begin(), mockData.end()),
+            testing::Return(static_cast<int>(mockData.size()))
+        ));
+
+    G29 g29;
+    ASSERT_NO_THROW({
+        
+        size_t bytesRead = g29.pump(100);
+        EXPECT_EQ(bytesRead, mockData.size());
+        std::cout << "Pump method read " << bytesRead << " bytes" << std::endl;
+    });
+}
+
+TEST_F(G29Test, GetStateReturnsCurrentState) {
+    EXPECT_CALL(*g_mockHidApi, hid_init()).WillOnce(testing::Return(0));
+    EXPECT_CALL(*g_mockHidApi, hid_open(0x046d, 0xc24f, testing::_)).WillOnce(testing::Return(reinterpret_cast<hid_device*>(1)));
+
+    G29 g29;
+    auto state = g29.getState();
+    EXPECT_FALSE(state.empty());
+}
+
+TEST_F(G29Test, IsButtonPressedChecksButtonState) {
+    EXPECT_CALL(*g_mockHidApi, hid_init()).WillOnce(testing::Return(0));
+    EXPECT_CALL(*g_mockHidApi, hid_open(0x046d, 0xc24f, testing::_)).WillOnce(testing::Return(reinterpret_cast<hid_device*>(1)));
+
+    G29 g29;
+    EXPECT_FALSE(g29.isButtonPressed("X"));
+
+    g29.updateButtonState({0x28, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05,0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05});
+    EXPECT_TRUE(g29.isButtonPressed("Square"));
+
+    g29.updateButtonState({0x18, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05,0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05});
+
+    EXPECT_TRUE(g29.isButtonPressed("X"));
+}
+
+// // Test case: No button pressed
+// TEST_F(G29Test, NoButtonPressedReturnsEmptyString) {
+//     EXPECT_CALL(*g_mockHidApi, hid_init()).WillOnce(testing::Return(0));
+//     EXPECT_CALL(*g_mockHidApi, hid_open(0x046d, 0xc24f, testing::_)).WillOnce(testing::Return(reinterpret_cast<hid_device*>(1)));
+    
+
+//     G29 g29;
+//     g29.updateButtonState({55});
+//     EXPECT_EQ(g29.getPressedButton(), "");
+// }
+
+// Test case: DPadUp button pressed
+TEST_F(G29Test, DPadUpButtonPressedReturnsDPadUp) {
+    EXPECT_CALL(*g_mockHidApi, hid_init()).WillOnce(testing::Return(0));
+    EXPECT_CALL(*g_mockHidApi, hid_open(0x046d, 0xc24f, testing::_)).WillOnce(testing::Return(reinterpret_cast<hid_device*>(1)));
+
+    G29 g29;
+    g29.updateButtonState({0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+    EXPECT_EQ(g29.getPressedButton(), "DPadUp");
+}
+
+// // Test case: Plus button pressed
+// TEST_F(G29Test, PlusButtonPressedReturnsPlusButton) {
+//     EXPECT_CALL(*g_mockHidApi, hid_init()).WillOnce(testing::Return(0));
+//     EXPECT_CALL(*g_mockHidApi, hid_open(0x046d, 0xc24f, testing::_)).WillOnce(testing::Return(reinterpret_cast<hid_device*>(1)));
+
+//     G29 g29;
+//     g29.updateButtonState({0xC8, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+//     EXPECT_EQ(g29.getPressedButton(), "PlusButton");
+// }
+
+// // Test case: L2 button pressed
+// TEST_F(G29Test, L2ButtonPressedReturnsL2) {
+//     EXPECT_CALL(*g_mockHidApi, hid_init()).WillOnce(testing::Return(0));
+//     EXPECT_CALL(*g_mockHidApi, hid_open(0x046d, 0xc24f, testing::_)).WillOnce(testing::Return(reinterpret_cast<hid_device*>(1)));
+
+//     G29 g29;
+//     g29.updateButtonState({0xC8, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+//     EXPECT_EQ(g29.getPressedButton(), "L2");
+// }
+
+
+
+
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION

This pull request introduces a  suite of unit tests for the G29 library. The main focus of these tests is to ensure the correct functionality of the G29 library methods and to verify that the integration with the hidAPI interface operates as expected.
Changes Made:

    Unit Tests Implementation:
        Developed a series of unit tests covering all critical functionalities of the G29 library, including button state updates and event handling.
        Each test case aims to validate the expected behavior of the library methods under various conditions.

    Mocking the hidAPI Interface:
        Implemented a mock version of the hidAPI interface to simulate hardware interactions. This allows for testing the G29 library without requiring physical hardware, facilitating a controlled and reproducible testing environment.
        The mock interface simulates the responses of the hardware, enabling us to test how the G29 library handles different button states and inputs from the device.